### PR TITLE
Update unicode_upper.rb

### DIFF
--- a/lib/rex/encoder/alpha2/unicode_upper.rb
+++ b/lib/rex/encoder/alpha2/unicode_upper.rb
@@ -52,7 +52,7 @@ class UnicodeUpper < Generic
       "TA" +                  # push esp, NOP
       "XA" +                  # pop eax, NOP
       "ZA" +                  # pop edx, NOP
-      "PU" +                  # push eax, NOP
+      "PA" +                  # push eax, NOP
       "3" +                   # xor eax, [eax]
       "QA" +                  # push ecx, NOP
       "DA" +                  # inc esp, NOP


### PR DESCRIPTION
"PU" converts to \x50\x00\x55\x00
Disassembly:

```
0:  50                  push   eax
1:  00 55 00            add    BYTE PTR [ebp+0x0],dl
```

But sometimes (as in my case) ebp points to non writable memory.
So i think better to use the same NOP as in other parts of the code

`1: 00 41 00                add    BYTE PTR [ecx+0x0],al `
